### PR TITLE
Create dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+WORKDIR /bpt
+
+COPY requirements.txt ./
+RUN apt-get update                                              && \
+    apt-get -y install libpq-dev gcc                            && \
+    pip3 install --no-cache-dir --upgrade -r ./requirements.txt && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY src/ ./
+CMD [ "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80" ]


### PR DESCRIPTION
This PR adds a dockerfile to build the project in the production server.

Notes:
- Some additional `apt` requirements have to be installed to enable the SQL connection
- Currently the server will run on port `80` but we might want to change to HTTPS (`:443`) later