### PR TITLE
Create docker-compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Deployment environment secrets
+.secrets/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+secrets:
+  db-passwd:
+    file: .secrets/db-passwd
+networks:
+  default:
+    name: prod-net
+    external: true
+
+services:
+  app:
+    build: .
+    image: bpt-server:latest
+    container_name: bpt-production
+    ports:
+      - 80:80
+    secrets:
+      - db-passwd
+    depends_on:
+      database:
+        condition: service_healthy
+  database:
+    image: postgres
+    container_name: db-production
+    restart: always
+    volumes:
+      - /bpt/production/db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db-passwd
+      POSTGRES_DB: bpt
+    secrets:
+      - db-passwd
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ virtualenv==20.16.5
 watchfiles==0.16.1
 watchgod==0.8.2
 websockets==10.3
+get-docker-secret==1.0.2

--- a/src/utilities/db.py
+++ b/src/utilities/db.py
@@ -1,16 +1,21 @@
+from dotenv import load_dotenv
+from get_docker_secret import get_docker_secret
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
-from dotenv import load_dotenv
-import os
-
 
 load_dotenv()
 
-DATABASE_URI = os.environ.get("DATABASE_URI")
+docker_db_passwd = get_docker_secret("db-passwd")
+env_db_uri = os.environ.get("DATABASE_URI")
 
-# Create database engine according to the database uri
-engine = create_engine(DATABASE_URI)
+engine = create_engine(
+    env_db_uri
+    if docker_db_passwd is None
+    else f"postgresql://postgres:{docker_db_passwd}@database/bpt"
+)
 
 # Create database session (given arguments for configurating session)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
This PR adds a `docker-compose` file to orchestrate running our server application and a database on the BPT virtual machine. As the file's been manually tested on the VM, I'm merging this without explicit review in GitHub.