### PR TITLE
Add server revision endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,11 +39,12 @@ def redirect_root():
 def get_rev_number():
     """Display the revision id and build date etc"""
     is_dev = SERVER_ENV == "development"
-    return (
-        "Berry Picker Tracker Server\n" "Local development"
+    details = (
+        "Local development"
         if is_dev
-        else (f"Code revision: {REV_NUMBER}" f"Running in {SERVER_ENV}")
+        else f"Code revision: {REV_NUMBER}\nRunning in {SERVER_ENV}"
     )
+    return f"Berry Picker Tracker Server\n{details}"
 
 
 @app.get("/nlsapi/{z}/{y}/{x}")

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,7 @@ def get_rev_number():
     """Display the revision id and build date etc"""
     is_dev = SERVER_ENV == "development"
     return (
-        "Berry Picker Tracker Server\n" "Local developemtn"
+        "Berry Picker Tracker Server\n" "Local development"
         if is_dev
         else (f"Code revision: {REV_NUMBER}" f"Running in {SERVER_ENV}")
     )

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,8 @@ from utilities.db import Base, engine
 load_dotenv()
 API_KEY = os.environ.get("NLS_API_KEY")
 LEGEND_URI = os.environ.get("LEGEND_URI")
+REV_NUMBER = os.environ.get("CODE_REVISION", "unknown")
+SERVER_ENV = os.environ.get("SERVER_ENVIRONMENT", "development")
 app = FastAPI()
 
 
@@ -31,6 +33,17 @@ def get_db():
 def redirect_root():
     """Root's warmest welcome"""
     return "G'day"
+
+
+@app.get("/server-version")
+def get_rev_number():
+    """Display the revision id and build date etc"""
+    is_dev = SERVER_ENV == "development"
+    return (
+        "Berry Picker Tracker Server\n" "Local developemtn"
+        if is_dev
+        else (f"Code revision: {REV_NUMBER}" f"Running in {SERVER_ENV}")
+    )
 
 
 @app.get("/nlsapi/{z}/{y}/{x}")


### PR DESCRIPTION
This PR adds an end-point to the api that shows the current code revision and deployment environment. Both values are loaded from the environment, and neither should be specified when in local development — i.e. the variables should only be set when running code on the virtual machine.

The deployment scripts in the VM need to be modified to inject the environment variables when running.

## Variables
- `CODE_REVISION` (`"unknown"` by default, will be set to the revision number — i.e. git hash, in the server)
- `SERVER_ENVIRONMENT` (`"development"` by default, will be set to either `"staging"` or `"production"` in the server)

## Todo before merge
- [x] Document the variables
- [x] Amend the `deploy.sh` scripts in the VM
- [x] Add unit test if deemed necessary